### PR TITLE
relax python requirements

### DIFF
--- a/fangfrisch/util.py
+++ b/fangfrisch/util.py
@@ -21,7 +21,7 @@ import os
 import re
 from string import Formatter
 from subprocess import CompletedProcess
-from subprocess import run
+from subprocess import run, PIPE
 from typing import Optional
 
 _byte_multipliers = {'K': 10 ** 3, 'KB': 2 ** 10, 'M': 10 ** 6, 'MB': 2 ** 20}
@@ -98,7 +98,7 @@ def run_command(command: str, timeout: int,
     p: CompletedProcess = None
     try:
         command = Formatter().vformat(command, args, kwargs)
-        p = run(command, capture_output=True, encoding='utf-8', shell=True, timeout=timeout)
+        p = run(command, stdout=PIPE, stderr=PIPE, encoding='utf-8', shell=True, timeout=timeout)
         if p.stdout:
             callback_stdout(p.stdout)
         if p.stderr:

--- a/setup.py
+++ b/setup.py
@@ -56,5 +56,5 @@ setuptools.setup(
         'requests >= 2.22.0',
         'SQLAlchemy >= 1.3.13',
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.6.10',
 )


### PR DESCRIPTION
Yes, I get it. python has moved on and 3.6 is not as shiny anymore. OpenSuse 15.4 still ships 3.6.15 as its default release, so you might consider merging these changes considering that they are quite small.