### PR TITLE
Add a systemd timer and service

### DIFF
--- a/contrib/fangfrisch.service
+++ b/contrib/fangfrisch.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=Updater for unofficial ClamAV signatures
+Documentation=man:fangfrisch(1)
+
+[Service]
+ExecStart=/usr/bin/fangfrisch --conf /etc/fangfrisch.conf refresh
+Type=oneshot
+User=clamav
+StateDirectory=fangfrisch
+StateDirectoryMode=0770
+ReadWritePaths=-/var/lib/clamav/
+PrivateDevices=yes
+PrivateTmp=yes
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=strict
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+CapabilityBoundingSet=
+SystemCallArchitectures=native
+SystemCallErrorNumber=EPERM
+SystemCallFilter=@system-service

--- a/contrib/fangfrisch.timer
+++ b/contrib/fangfrisch.timer
@@ -1,7 +1,7 @@
 [Unit]
 Description=Automatically refresh the fangfrisch signatures
 Documentation=man:fangfrisch(1)
-ConditionPathExists=/etc/fangfrisch.conf
+ConditionPathExists=/var/lib/fangfrisch/db.sqlite
 
 [Timer]
 OnBootSec=2min

--- a/contrib/fangfrisch.timer
+++ b/contrib/fangfrisch.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Automatically refresh the fangfrisch signatures
+Documentation=man:fangfrisch(1)
+ConditionPathExists=/etc/fangfrisch.conf
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=15min
+RandomizedDelaySec=2m
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
This commit contains the systemd timer and service units needed to run fangfrisch.
Due to `ConditionPathExists=/etc/fangfrisch.conf`, the timer will be triggered only if the configuration file exists.
The service unit uses plenty of sandboxing to strictly limit access to the system in the event an attacker managed to take control of the program.